### PR TITLE
added derive attribute to get the tree types to clone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "coitrees"
 description = "A very fast data structure for overlap queries on sets of intervals."
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Daniel C. Jones <djones3@fredhutch.org>"]
 edition = "2021"
 repository = "https://github.com/dcjones/coitrees"

--- a/src/avx.rs
+++ b/src/avx.rs
@@ -383,6 +383,7 @@ where
 /// The index type `I` is a typically `usize`, but can be `u32` or `u16`.
 /// It's slightly more efficient to use a smalled index type, assuming there are
 /// fewer than I::MAX-1 intervals to store.
+#[derive(Clone)]
 pub struct AVXCOITree<T, I>
 where
     T: Clone,

--- a/src/neon.rs
+++ b/src/neon.rs
@@ -275,6 +275,7 @@ fn count_bits(bits: uint32x4_t) -> usize {
 /// The index type `I` is a typically `usize`, but can be `u32` or `u16`.
 /// It's slightly more efficient to use a smalled index type, assuming there are
 /// fewer than I::MAX-1 intervals to store.
+#[derive(Clone)]
 pub struct NeonCOITree<T, I>
 where
     T: Clone,

--- a/src/nosimd.rs
+++ b/src/nosimd.rs
@@ -121,6 +121,7 @@ fn test_interval_len() {
 /// The index type `I` is a typically `usize`, but can be `u32` or `u16`.
 /// It's slightly more efficient to use a smalled index type, assuming there are
 /// fewer than I::MAX-1 intervals to store.
+#[derive(Clone)]
 pub struct BasicCOITree<T, I>
 where
     T: Clone,


### PR DESCRIPTION
I needed to clone the tree types and found this trait wasn't implemented for these. I've added derive attributes for each `struct`. 