### PR TITLE
Add implementation of IntWithMax for u64

### DIFF
--- a/src/interval.rs
+++ b/src/interval.rs
@@ -149,6 +149,10 @@ impl IntWithMax for usize {
     const MAX: usize = usize::MAX;
 }
 
+impl IntWithMax for u64 {
+    const MAX: u64 = u64::MAX;
+}
+
 impl IntWithMax for u32 {
     const MAX: u32 = u32::MAX;
 }


### PR DESCRIPTION
Pretty simple, it would be nice if u64 could be used as the index type. I didn't really check whether there is any issue with doing this :P